### PR TITLE
Support definitions with basic types

### DIFF
--- a/src/test/java/com/ethlo/schematools/jsons2xsd/ConversionTest.java
+++ b/src/test/java/com/ethlo/schematools/jsons2xsd/ConversionTest.java
@@ -60,6 +60,16 @@ public class ConversionTest
 		}
 	}
 
+	@Test
+	public void testOtherDefinition() throws IOException, TransformerException
+	{
+		try (final Reader r = new InputStreamReader(getClass().getResourceAsStream("/schema/definitionwithbasictype.json")))
+		{
+			final Document doc = Jsons2Xsd.convert(r, "http://cableapi.cablelabs.com/schemas/v1/DefinitionWithBasicType", OuterWrapping.ELEMENT, "DefinitionWithBasicType");
+			System.out.println(XmlUtil.asXmlString(doc.getDocumentElement()));
+		}
+	}
+
 	private Document doConvert(String file) throws IOException
 	{
 		try (final Reader r = new InputStreamReader(getClass().getResourceAsStream(file)))

--- a/src/test/resources/schema/definitionwithbasictype.json
+++ b/src/test/resources/schema/definitionwithbasictype.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Other Definition",
+    "type": "object",
+
+    "definitions": {
+        "TestEnum": {
+            "enum": [
+                "A",
+                "B",
+                "C",
+                "D"
+            ]
+        },
+        "Item": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Value": {
+                    "$ref": "#/definitions/GUID"
+                },
+                "Type": {
+                    "$ref": "#/definitions/TestEnum"
+                }
+            },
+            "required": [
+                "Value",
+                "Type"
+            ]
+        },
+        "GUID": {
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "type": "string"
+        },
+        "TestArray": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/Item" }
+        }
+    },
+
+    "properties": {
+        "content": { "$ref": "#/definitions/TestArray" }
+    },
+    
+    "required": [
+        "content"
+    ]
+}


### PR DESCRIPTION
This pull request is related to Issue #6.

Add type generating for enum definitions.
For definitions with basic type, I record their json content and use them to replace the "$ref" Node.

I'm not good at java, so tell me if anything is wrong.

I removed the special "Link" part in doIterateDefinition() because it seems useless and may cause unexpected result. Tell me if this part is important for you.
