### PR TITLE
Avoid NPE, update pom to 2.3.0

### DIFF
--- a/jsons2xsd.iml
+++ b/jsons2xsd.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" version="4">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ethlo.jsons2xsd</groupId>
 	<artifactId>jsons2xsd</artifactId>
-	<version>2.2.1</version>
+	<version>2.3.0</version>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ethlo.jsons2xsd</groupId>
 	<artifactId>jsons2xsd</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>

--- a/src/main/java/com/ethlo/jsons2xsd/Assert.java
+++ b/src/main/java/com/ethlo/jsons2xsd/Assert.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/ethlo/jsons2xsd/Config.java
+++ b/src/main/java/com/ethlo/jsons2xsd/Config.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/ethlo/jsons2xsd/InvalidXsdSchema.java
+++ b/src/main/java/com/ethlo/jsons2xsd/InvalidXsdSchema.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/ethlo/jsons2xsd/JsonComplexType.java
+++ b/src/main/java/com/ethlo/jsons2xsd/JsonComplexType.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/ethlo/jsons2xsd/JsonSimpleType.java
+++ b/src/main/java/com/ethlo/jsons2xsd/JsonSimpleType.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/ethlo/jsons2xsd/Jsons2Xsd.java
+++ b/src/main/java/com/ethlo/jsons2xsd/Jsons2Xsd.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -12,10 +12,10 @@ package com.ethlo.jsons2xsd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,17 +26,17 @@ package com.ethlo.jsons2xsd;
  * #L%
  */
 
+import java.io.IOException;
+import java.io.Reader;
+import java.util.*;
+import java.util.Map.Entry;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.util.*;
-import java.util.Map.Entry;
 
 public class Jsons2Xsd
 {

--- a/src/main/java/com/ethlo/jsons2xsd/Jsons2Xsd.java
+++ b/src/main/java/com/ethlo/jsons2xsd/Jsons2Xsd.java
@@ -57,6 +57,7 @@ public class Jsons2Xsd
     private static final String XSD_VALUE = "value";
     private static final String XSD_CHOICE = "choice";
 
+    private static final String XSD_SCHEMA = "schema";
     private static final String XSD_OBJECT = "object";
     private static final String XSD_ARRAY = "array";
 
@@ -193,7 +194,7 @@ public class Jsons2Xsd
         final Document xsdDoc = XmlUtil.newDocument();
         xsdDoc.setXmlStandalone(true);
 
-        final Element schemaRoot = element(xsdDoc, "schema");
+        final Element schemaRoot = element(xsdDoc, XSD_SCHEMA);
         schemaRoot.setAttribute("targetNamespace", cfg.getTargetNamespace());
         schemaRoot.setAttribute("xmlns:" + cfg.getNsAlias(), cfg.getTargetNamespace());
         schemaRoot.setAttribute("elementFormDefault", "qualified");
@@ -362,7 +363,7 @@ public class Jsons2Xsd
                 break;
 
             default:
-                if (nodeElem.getNodeName().equals("schema")) {
+                if (nodeElem.getNodeName().equals(XSD_SCHEMA)) {
                     final Element simpleType = element(nodeElem, XSD_SIMPLETYPE);
                     final Element restriction = element(simpleType, XSD_RESTRICTION);
                     restriction.setAttribute("base", xsdType);
@@ -393,7 +394,7 @@ public class Jsons2Xsd
         final Integer maximumLength = getIntVal(val, "maxLength");
         final String expression = val.path("pattern").textValue();
 
-        if (minimumLength != null || maximumLength != null || expression != null || nodeElem.getNodeName().equals("schema"))
+        if (minimumLength != null || maximumLength != null || expression != null || nodeElem.getNodeName().equals(XSD_SCHEMA))
         {
             nodeElem.removeAttribute("type");
             final Element simpleType = element(nodeElem, XSD_SIMPLETYPE);
@@ -442,7 +443,7 @@ public class Jsons2Xsd
         final Long minimum = getLongVal(jsonNode, "minimum");
         final Long maximum = getLongVal(jsonNode, "maximum");
 
-        if (minimum != null || maximum != null || nodeElem.getNodeName().equals("schema"))
+        if (minimum != null || maximum != null || nodeElem.getNodeName().equals(XSD_SCHEMA))
         {
             nodeElem.removeAttribute("type");
             final Element simpleType = element(nodeElem, XSD_SIMPLETYPE);
@@ -475,7 +476,7 @@ public class Jsons2Xsd
 
     private static void handleArray(Set<String> neededElements, Element nodeElem, JsonNode jsonNode, Config cfg)
     {
-        final JsonNode arrItems = jsonNode.path("items");
+        final JsonNode arrItems = jsonNode.path(FIELD_ITEMS);
         final String arrayXsdType = determineXsdType(cfg, arrItems.path("type").textValue(), arrItems);
         if (cfg.isUnwrapArrays()) {
             handleArrayElements(neededElements, jsonNode, arrItems, arrayXsdType, nodeElem, cfg);
@@ -538,11 +539,11 @@ public class Jsons2Xsd
         {
             return TYPE_ENUM;
         }
-        else if (hasProperties || jsonType.equalsIgnoreCase(JsonComplexType.OBJECT_VALUE))
+        else if (hasProperties || JsonComplexType.OBJECT_VALUE.equalsIgnoreCase(jsonType))
         {
             return XsdComplexType.OBJECT_VALUE;
         }
-        else if (jsonType.equalsIgnoreCase(JsonComplexType.ARRAY_VALUE))
+        else if (JsonComplexType.ARRAY_VALUE.equalsIgnoreCase(jsonType))
         {
             return XsdComplexType.ARRAY_VALUE;
         }

--- a/src/main/java/com/ethlo/jsons2xsd/XmlUtil.java
+++ b/src/main/java/com/ethlo/jsons2xsd/XmlUtil.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,14 @@ package com.ethlo.jsons2xsd;
  * #L%
  */
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -33,28 +41,13 @@ import java.io.UncheckedIOException;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParserFactory;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Result;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
+import com.sun.xml.xsom.parser.XSOMParser;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-
-import com.sun.xml.xsom.parser.XSOMParser;
 
 public class XmlUtil
 {

--- a/src/main/java/com/ethlo/jsons2xsd/XsdComplexType.java
+++ b/src/main/java/com/ethlo/jsons2xsd/XsdComplexType.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/ethlo/jsons2xsd/XsdSimpleType.java
+++ b/src/main/java/com/ethlo/jsons2xsd/XsdSimpleType.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/ethlo/jsons2xsd/ConversionTest.java
+++ b/src/test/java/com/ethlo/jsons2xsd/ConversionTest.java
@@ -4,7 +4,7 @@ package com.ethlo.jsons2xsd;
  * #%L
  * jsons2xsd
  * %%
- * Copyright (C) 2014 - 2020 Morten Haraldsen (ethlo)
+ * Copyright (C) 2014 - 2021 Morten Haraldsen (ethlo)
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -12,10 +12,10 @@ package com.ethlo.jsons2xsd;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,9 +26,6 @@ package com.ethlo.jsons2xsd;
  * #L%
  */
 
-import org.junit.Test;
-import org.w3c.dom.Document;
-
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -38,6 +35,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import org.w3c.dom.Document;
 
 public class ConversionTest {
     @Test


### PR DESCRIPTION
I have fixed possible NPEs and hopefully updated the pom correctly to reflect the current version that is available through maven central. Of course, you are free to only update the NPE stuff.
I am also looking into skipping $Id tags, but that might become a different version.